### PR TITLE
update index.js to write content_type in gridfs

### DIFF
--- a/index.js
+++ b/index.js
@@ -237,6 +237,8 @@ module.exports = function GridFSStore (globalOpts) {
                     var outs = gfs.createWriteStream({
                         filename: fd,
                         root: options.bucket,
+                        mode: 'w',
+                        content_type: options.content_type,
                         metadata: {
                             fd: fd,
                             dirname: __newFile.dirname || path.dirname(fd)


### PR DESCRIPTION
when createWriteStream(), you can pass the param "options.content_type" to write content_type in gridfs