### PR TITLE
Connection options

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ One important adapter-specific option to note is `uri`:
 | Option        | Type       | Details |
 |-----------    |:----------:|---------|
 | `uri`         | ((string)) | An optional parameter if you wish the enter your mongodb credentials as a URI, e.g. `mongodb://username:password@localhost:27107/databasename.bucket`.<br/> (Check [mongo client URI syntax](http://api.mongodb.org/java/current/com/mongodb/MongoClientURI.html)).|
-| `connectOpts` | ((object)) | An optional parameter if you wish the enter your mongodb connection options credentials as an object e.g. { server: { ssl: true, sslCA: 'CA_CERT', sslKey: 'SSL_KEY', sslCert: 'SSL_CERT' }, replSet: { rs_name: 'rs0', ssl:true} } <br/> (Check [mongo client connection options]((https://mongodb.github.io/node-mongodb-native/api-generated/mongoclient.html#connect)).|
+| `connectOpts` | ((object)) | An optional parameter if you wish the enter your mongodb connection options credentials as an object e.g. `{ server: { ssl: true, sslCA: 'CA_CERT', sslKey: 'SSL_KEY', sslCert: 'SSL_CERT' }, replSet: { rs_name: 'rs0', ssl:true} }` <br/> (Check [mongo client connection options](https://mongodb.github.io/node-mongodb-native/api-generated/mongoclient.html#connect)).|
 
 >>Note:
 >>Please use `uri` instead of passing in separate options for `username`, `password`, `host`, `port`, `dbname` and `bucket`

--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ For more detailed usage information and a full list of available options, see th
 
 One important adapter-specific option to note is `uri`:
 
-| Option    | Type       | Details |
-|-----------|:----------:|---------|
-| `uri`     | ((string)) | An optional parameter if you wish the enter your mongodb credentials as a URI, e.g. `mongodb://username:password@localhost:27107/databasename.bucket`.<br/> (Check [mongo client URI syntax](http://api.mongodb.org/java/current/com/mongodb/MongoClientURI.html)).|
+| Option        | Type       | Details |
+|-----------    |:----------:|---------|
+| `uri`         | ((string)) | An optional parameter if you wish the enter your mongodb credentials as a URI, e.g. `mongodb://username:password@localhost:27107/databasename.bucket`.<br/> (Check [mongo client URI syntax](http://api.mongodb.org/java/current/com/mongodb/MongoClientURI.html)).|
+| `connectOpts` | ((object)) | An optional parameter if you wish the enter your mongodb connection options credentials as an object e.g. { server: { ssl: true, sslCA: 'CA_CERT', sslKey: 'SSL_KEY', sslCert: 'SSL_CERT' }, replSet: { rs_name: 'rs0', ssl:true} } <br/> (Check [mongo client connection options]((https://mongodb.github.io/node-mongodb-native/api-generated/mongoclient.html#connect)).|
 
 >>Note:
 >>Please use `uri` instead of passing in separate options for `username`, `password`, `host`, `port`, `dbname` and `bucket`

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = function GridFSStore (globalOpts) {
     var adapter = {
         ls: function (dirname, cb) {
 
-            MongoClient.connect(globalOpts.uri, {native_parser: true}, function (err, db) {
+            MongoClient.connect(globalOpts.uri, _getOptions(), function (err, db) {
                 if (err) {
                     return cb(err);
                 }
@@ -71,7 +71,7 @@ module.exports = function GridFSStore (globalOpts) {
         },
 
         read: function (fd, cb) {
-            MongoClient.connect(globalOpts.uri, {native_parser: true}, function (err, db) {
+            MongoClient.connect(globalOpts.uri, _getOptions(), function (err, db) {
                 if (err) {
                     return cb(err);
                 }
@@ -120,7 +120,7 @@ module.exports = function GridFSStore (globalOpts) {
         },
 
         readVersion: function (fd, version, cb) {
-            MongoClient.connect(globalOpts.uri, {native_parser: true}, function (err, db) {
+            MongoClient.connect(globalOpts.uri, _getOptions(), function (err, db) {
                 if (err) {
                     return cb(err);
                 }
@@ -184,7 +184,7 @@ module.exports = function GridFSStore (globalOpts) {
         },
 
         rm: function (fd, cb) {
-            MongoClient.connect(globalOpts.uri, {native_parser: true}, function (err, db) {
+            MongoClient.connect(globalOpts.uri, _getOptions(), function (err, db) {
                 if (err) {
                     return cb(err);
                 }
@@ -227,7 +227,7 @@ module.exports = function GridFSStore (globalOpts) {
                     done(err);
                 });
 
-                MongoClient.connect(globalOpts.uri, {native_parser: true}, function (err, db) {
+                MongoClient.connect(globalOpts.uri, _getOptions(), function (err, db) {
                     if (err) {
                         receiver__.emit('error', err);
                     }
@@ -280,6 +280,9 @@ module.exports = function GridFSStore (globalOpts) {
 
     // Helper methods:
     ////////////////////////////////////////////////////////////////////////////////
+    function _getOptions() {
+      return _.assign(globalOpts.connectOpts, { native_parser: true });
+    }
 
     function _setURI() {
         if (!globalOpts.uri || !_URIisValid(globalOpts.uri)) {
@@ -357,7 +360,7 @@ module.exports = function GridFSStore (globalOpts) {
             if (db) {
                 cb(db);
             } else {
-                MongoClient.connect(opts.uri, {native_parser: true}, function (err, _db) {
+                MongoClient.connect(opts.uri, _getOptions(), function (err, _db) {
                     db = _db;
                     cb(db, err);
                 });

--- a/index.js
+++ b/index.js
@@ -281,7 +281,7 @@ module.exports = function GridFSStore (globalOpts) {
     // Helper methods:
     ////////////////////////////////////////////////////////////////////////////////
     function _getOptions() {
-      return _.assign(globalOpts.connectOpts, { native_parser: true });
+      return _.assign(globalOpts.connectOpts || {}, { native_parser: true });
     }
 
     function _setURI() {


### PR DESCRIPTION
The ability to use skipper-gridfs in a mongo environment that uses two-way SSL, plus authenticating replSet, is dependent upon the ability to provide additional connection options. Without this ability, connection to the mongo instances cannot be obtained as ssl features (such as CA's, certs, and keys) as well as additional replset configurations cannot be passed through a mongo uri.