### PR TITLE
Version 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 GridFS adapter for receiving [upstreams](https://github.com/balderdashy/skipper#what-are-upstreams). Particularly useful for handling streaming multipart file uploads from the [Skipper](https://github.com/balderdashy/skipper) body parser.
 
+Currently only supports Node 6 and up
+
 
 ========================================
 
@@ -27,7 +29,7 @@ Also make sure you have skipper [installed as your body parser](http://beta.sail
 req.file('avatar')
 .upload({
   adapter: require('skipper-gridfs'),
-  uri: 'mongodb://jimmy@j1mtr0n1xx@mongo.jimmy.com:27017/myBucket'
+  uri: 'mongodb://username:password@myhost.com:27017/myDatabase'
 }, function whenDone(err, uploadedFiles) {
   if (err) return res.negotiate(err);
   else return res.ok({

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = function SkipperGridFS(globalOptions) {
                 errorHandler(err, client);
             }
 
-            bucket(client.db(), options.bucketOptions).delete(fd._id, errorHandler);
+            bucket(client.db(), options.bucketOptions).delete(fd, (err) => errorHandler(err, client));
             if (cb) cb();
         });
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skipper-gridfs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A skipper adapter to allow uploading files to MongoDB's GridFS",
   "main": "index.js",
   "scripts": {
@@ -27,6 +27,7 @@
     "skipper-adapter-tests": "github:willhuang85/skipper-adapter-tests#master"
   },
   "dependencies": {
+    "concat-stream": "^1.6.2",
     "lodash": "^4.17.11",
     "mime": "^2.3.1",
     "mongodb": "^3.1.8"


### PR DESCRIPTION
Correct `ls` to return array of file path's instead of the whole document object
Correct `read` and `rm` to use `fd` as a string instead of an object
Ability to use callback function for `read` instead of only a stream