### PR TITLE
Adding 'info' functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,6 +174,48 @@ module.exports = function SkipperGridFS(globalOptions) {
         }
         return receiver__;
     }
+
+    adapter.info = (fd, cb) => {
+        const errorHandler = (err, client) => {
+            if (client) client.close();
+            if (cb) cb(err);
+        }
+
+        const __transform__ = Transform({ objectMode: true });
+        __transform__._transform = (fileInfo, encoding, callback) => {
+            return callback(null, fileInfo);
+        };
+
+        __transform__.once('done', (client) => {
+            client.close();
+        });
+
+
+        client(options.uri, options.mongoOptions, (err, client) => {
+            if (err) {
+                errorHandler(err, client);
+            }
+
+            const stream = bucket(client.db(), options.bucketOptions).find({ 'metadata.fd' : fd }).transformStream();
+            stream.once('error', (err) => {
+                errorHandler(err, client);
+            });
+
+            stream.once('end', () => {
+                __transform__.emit('done', client);
+            });
+
+            stream.pipe(__transform__);
+        });
+
+        if (cb) {
+            __transform__.pipe(concat((data) => {
+                return cb(null, Array.isArray(data) ? data : [data]);
+            }));
+        } else {
+            return __transform__;
+        }
+    }
     return adapter;
 };
 


### PR DESCRIPTION
**Why this PR?**
Adds 'adapter.info' function, in order to allow fetch data regarding one particular file, such as:
- length
- chunckSize
- fileName (Original file name when uploaded)
- md5
- contentType
- metadata
-- fileName
-- fd
-- dirName

It is useful when you need to grab details about the file that is being retrieved from GridFS.

**Use example**

```
// First, get info about the file
let me = this;
fileAdapter.info(user.avatarFd, function(error,info){
   if(error){
      return exits.serverError(error);
   } else {
      // Use info to populate response fields
      me.res.set("Content-type", info[0].contentType);
      me.res.set("Content-disposition", contentDisposition(info[0].filename, { type: 'inline'}));
      
      // Then, stream the file down
      fileAdapter.read(user.avatarFd, function(error,file){
         if(error){
            return exits.serverError(error);
         } else {
            return exits.success(new Buffer.from(file));
         }
      })
   }
})

```

Disclaimer
>I'm a rookie at Node and Github. If I'm doing anything wrong or not convenient, feel free to edit or delete it.