### PR TITLE
Fix: callback being called twice.

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,8 +37,14 @@ module.exports = function SkipperGridFS(globalOptions) {
                 errorHandler(err, client);
             }
 
-            bucket(client.db(), options.bucketOptions).delete(fd, (err) => errorHandler(err, client));
-            if (cb) cb();
+            bucket(client.db(), options.bucketOptions).delete(fd, (err) => { 
+                if(err){
+                    errorHandler(err, client);
+                } 
+                else if (cb){
+                    cb();
+                } 
+            });
         });
     }
 

--- a/index.js
+++ b/index.js
@@ -160,14 +160,7 @@ module.exports = function SkipperGridFS(globalOptions) {
                 });
                 outs__.once('error', (err) => {
                     if (client) client.close();
-                    return done({
-                        incoming: __newFile,
-                        outgoing: outs__,
-                        code: 'E_WRITE',
-                        stack: typeof err === 'object' ? err.stack : new Error(err),
-                        name: typeof err === 'object' ? err.name : err,
-                        message: typeof err === 'object' ? err.message : err
-                    });
+                    return done(err);
                 });
 
                 __newFile.pipe(outs__);

--- a/index.js
+++ b/index.js
@@ -128,20 +128,11 @@ module.exports = function SkipperGridFS(globalOptions) {
     adapter.receive = (opts) => {
         const receiver__ = WritableStream({ objectMode: true });
 
-        receiver__.once('done', (client, done) => {
-            if (client) client.close();
-            if (done) done();
-        });
-
-        receiver__.once('error', (error, client, done) => {
-            if (client) client.close();
-            if (done) done(error);
-        });
-
-        receiver__.write = (__newFile, encoding, done) => {
+        receiver__._write = (__newFile, encoding, done) => {
             client(options.uri, options.mongoOptions, (error, client) => {
                 if (error) {
-                    receiver__.emit('error', error, client, done);
+                    if (client) client.close();
+                    if (done) done(error);
                 }
 
                 const fd = __newFile.fd;
@@ -155,18 +146,22 @@ module.exports = function SkipperGridFS(globalOptions) {
                     },
                     contentType: mime.getType(fd)
                 });
-
-                __newFile.once('close', () => {
-                    receiver__.emit('done', client, done);
-                });
-                __newFile.once('error', (error) => {
-                    receiver__.emit('error', error, client, done);
-                });
+               
                 outs__.once('finish', () => {
-                    receiver__.emit('done', client, done);
+                    receiver__.emit('writefile', __newFile);
+                    if (client) client.close();
+                    done();
                 });
-                outs__.once('error', (error) => {
-                    receiver__.emit('error', error, client, done);
+                outs__.once('error', (err) => {
+                    if (client) client.close();
+                    return done({
+                        incoming: __newFile,
+                        outgoing: outs__,
+                        code: 'E_WRITE',
+                        stack: typeof err === 'object' ? err.stack : new Error(err),
+                        name: typeof err === 'object' ? err.name : err,
+                        message: typeof err === 'object' ? err.message : err
+                    });
                 });
 
                 __newFile.pipe(outs__);

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
   },
   "homepage": "https://github.com/willhuang85/skipper-gridfs",
   "devDependencies": {
-    "skipper-adapter-tests": "github:willhuang85/skipper-adapter-tests#master"
+    "skipper-adapter-tests": "^2.0.0"
   },
   "dependencies": {
     "concat-stream": "^1.6.2",
     "lodash": "^4.17.11",
     "mime": "^2.3.1",
-    "mongodb": "^3.1.8"
+    "mongodb": "^3.6.5"
   }
 }


### PR DESCRIPTION
This branch fixes a bug that makes `cb()` being called twice inside `adapter.rm()` function.

This was causing Parley to pop-up the following warning inside Sails:

```
WARNING: Something seems to be wrong with this function.
It is trying to signal that it has finished AGAIN, after
already resolving/rejecting once.
(silently ignoring this...)
```
